### PR TITLE
A fix for #20

### DIFF
--- a/src/javaServerStarter.ts
+++ b/src/javaServerStarter.ts
@@ -64,7 +64,7 @@ function prepareParams(requirements: RequirementsData, config: ServerConfigurati
   }
   let { vmargs, root } = config
   const encodingKey = '-Dfile.encoding='
-  if (vmargs.indexOf(encodingKey) < 0) {
+  if (vmargs.indexOf(encodingKey) < 0 && config.encoding) {
     params.push(encodingKey + config.encoding)
   }
   if (os.platform() == 'win32') {


### PR DESCRIPTION
Check if config.encoding is specified, if not, `-Dfile.encoding=` won't be added to the vm args, otherwise jvm will fail to start with `java.nio.charset.IllegalCharsetNameException`