### PR TITLE
Added setting "java.project.referencedLibraries".

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,6 +182,32 @@
           ],
           "scope": "window"
         },
+        "java.project.referencedLibraries": {
+          "type": [
+            "array",
+            "object"
+          ],
+          "description": "Configure glob patterns for referencing local libraries to a Java project.",
+          "default": [
+            "lib/**/*.jar"
+          ],
+          "properties": {
+            "include": {
+              "type": "array"
+            },
+            "exclude": {
+              "type": "array"
+            },
+            "sources": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "include"
+          ],
+          "additionalProperties": false,
+          "scope": "window"
+        },
         "java.contentProvider.preferred": {
           "type": "string",
           "description": "Preferred content provider (a 3rd party decompiler id, usually)",


### PR DESCRIPTION
This allows users to set the property in `.vim/coc-settings` in their project folder to add external libraries, similar to how VSCode works.

I just copied the relevant part of `vscode-java`'s properties. Since they both have EPL, I think this is fine, but I'm not very familiar with the licence, so please double check that this is okay.