### PR TITLE
import: call given function instead of prompting

### DIFF
--- a/package.json
+++ b/package.json
@@ -383,6 +383,11 @@
           "description": "Limit number of items in arrays/collections/maps to list, if 0 then list all.",
           "default": 0,
           "scope": "window"
+        },
+        "java.import.callback": {
+          "type": "string",
+          "description": "Name of vim function to call for choosing import candidates",
+          "scope": "window"
         }
       }
     },


### PR DESCRIPTION
This changeset adds an ability to specify a vim function that will be called and
the import candidates will be passed to this function. If the function returns a
result that is not equal to -1 it will be used instead of prompting the user for
choosing type to import.

This ability opens a door for writing custom auto-importers based on existing
project codebase and used imports. For example, an end-user could write a vim
function that will return the most used import from the candidates.

I didn't edit Readme because I'm not sure what release version will be next and left
it for the maintainers of the project.