### PR TITLE
move the cursor to ambiguous import choices only if callback did not help

### DIFF
--- a/src/sourceAction.ts
+++ b/src/sourceAction.ts
@@ -150,8 +150,6 @@ function registerChooseImportCommand(context: ExtensionContext): void {
     // tslint:disable-next-line: prefer-for-of
     for (let i = 0; i < selections.length; i++) {
       const selection: ImportSelection = selections[i]
-      // Move the cursor to the code line with ambiguous import choices.
-      await workspace.moveTo(selection.range.start)
       const candidates: ImportCandidate[] = selection.candidates
       const fullyQualifiedName = candidates[0].fullyQualifiedName
       const typeName = fullyQualifiedName.substring(fullyQualifiedName.lastIndexOf(".") + 1)
@@ -164,6 +162,9 @@ function registerChooseImportCommand(context: ExtensionContext): void {
             break
           }
         }
+
+        // Move the cursor to the code line with ambiguous import choices.
+        await workspace.moveTo(selection.range.start)
 
         let res = await workspace.showQuickpick(candidates.map(o => o.fullyQualifiedName), `Choose type '${typeName}' to import`)
         if (res == -1) {


### PR DESCRIPTION
If the callback can automatically choose an import, then there is no need to jump to this line.

An example of such callback: https://github.com/reconquest/vim-pythonx/blob/master/rplugin/python3/plugin.py#L20 