### PR TITLE
Add "java.configuration.runtimes" to package.json contributed configuration.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,6 +27,29 @@ The path to the Java Development Kit is searched in the following order:
 - the `JAVA_HOME` environment variable
 - on the current system path
 
+This JDK will be used to launch the Java Language Server. And by default, will be used to compile your projects.
+
+If you need to compile your projects against a different JDK version, it's recommended you configure the `java.configuration.runtimes` property in your user settings, eg:
+
+```json
+"java.configuration.runtimes": [
+  {
+    "name": "JavaSE-1.8",
+    "path": "/path/to/jdk-8",
+  },
+  {
+    "name": "JavaSE-11",
+    "path": "/path/to/jdk-11",
+  },
+  {
+    "name": "JavaSE-14",
+    "path": "/path/to/jdk-14",
+    "default": true
+  },
+]
+```
+The default runtime will be used when you open standalone Java files.
+
 # Features
 
 - Maven pom.xml project support
@@ -92,6 +115,7 @@ The following settings are supported:
 - `java.completion.enabled` : Enable/disable code completion support.
 - `java.clean.workspace` : Clean the Java language server workspace.
 - `java.foldingRange.enabled`: Enable/disable smart folding range support. If disabled, it will use the default indentation-based folding range provided by VS Code.
+* `java.configuration.runtimes`: Map Java Execution Environments to local JDKs.
 
 New in 1.3.0:
 

--- a/package.json
+++ b/package.json
@@ -419,6 +419,55 @@
           "type": "string",
           "description": "Name of vim function to call for choosing import candidates",
           "scope": "window"
+        },
+        "java.configuration.runtimes": {
+          "type": "array",
+          "description": "Map Java Execution Environments to local JDKs.",
+          "items": {
+            "type": "object",
+            "default": {},
+            "required": [
+              "path",
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "enum": [
+                  "J2SE-1.5",
+                  "JavaSE-1.6",
+                  "JavaSE-1.7",
+                  "JavaSE-1.8",
+                  "JavaSE-9",
+                  "JavaSE-10",
+                  "JavaSE-11",
+                  "JavaSE-12",
+                  "JavaSE-13",
+                  "JavaSE-14"
+                ],
+                "description": "Java Execution Environment name. Must be unique."
+              },
+              "path": {
+                "type": "string",
+                "description": "JDK path.\nOn Windows, backslashes must be escaped, i.e.\n\"path\":\"C:\\\\Program Files\\\\Java\\\\jdk1.8.0_161\"."
+              },
+              "sources": {
+                "type": "string",
+                "description": "JDK sources path."
+              },
+              "javadoc": {
+                "type": "string",
+                "description": "JDK javadoc path."
+              },
+              "default": {
+                "type": "boolean",
+                "description": "Is default runtime? Only one runtime can be default."
+              }
+            },
+            "additionalProperties": false
+          },
+          "default": [],
+          "scope": "machine"
         }
       }
     },


### PR DESCRIPTION
See eclipse/eclipse.jdt.ls#1309
and
https://github.com/redhat-developer/vscode-java/blob/master/package.json#L472-L520

relates to #103 
relates to #106