### PR TITLE
Get rid of npm-run-all

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "clean": "rimraf lib",
     "build": "webpack",
-    "prepare": "npx npm-run-all clean build"
+    "prepare": "webpack"
   },
   "activationEvents": [
     "onLanguage:java",


### PR DESCRIPTION
`npm-run-all` do not work properly with npm 7 and also it haven't updated for 2 years.

###### Reference
- https://github.com/neoclide/coc-tsserver/pull/234