### PR TITLE
include .git as workspace root

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
       {
         "filetype": "java",
         "patterns": [
+          ".git",
           "package.json",
           ".project",
           ".classpath",


### PR DESCRIPTION
In a multiproject setup, if one opens a subproject file first, the workspace
root will be detected as a subproject which JDT.ls won't find dependent
projects. Include `.git` as the first level of workspace root should alleviate
this problem
