### PR TITLE
exposing jdt.ls configuration for including additional sourcePaths

### DIFF
--- a/package.json
+++ b/package.json
@@ -263,6 +263,14 @@
           ],
           "scope": "window"
         },
+        "java.project.sourcePaths": {
+          "type": [
+            "array"
+          ],
+          "description": "Relative paths for including additional paths for source code within a Java project.",
+          "default": null,
+          "scope": "window"
+        },
         "java.project.referencedLibraries": {
           "type": [
             "array",


### PR DESCRIPTION
Source paths is a critical configuration for projects that
1. don't use maven/gradle
2. separate the source / tests in different directories 
3. have some other non-standard / unrecognizable build system

These type of projects are termed "Invisible projects" by jdt.ls and they are synonymous to an Eclipse project - ref. eclipse/eclipse.jdt.ls#1986

In this PR, I'm exposing the configuration to add additional source paths. I am not sure why this configuration was not already exposed, so hopefully i am not missing an intentional reason to not expose this. Without setting this configuration, source code in different directories will fail to be recognized with warning like

> $className.java is not on the classpath of project $projectName, only syntax errors are reported

coc-java's default behavior when compiling a workspace for an "invisible project" is to generate a workspace directory with a .classpath file that has a single source entry that is referencing whatever source code path is opened first. So, if I opened my main code first, then my unittests were unrecognized and vice versa.

Attempting to fix this with a `$CLASSPATH` environment variable, and with `java.project.referencedLibraries` does not work. `$CLASSPATH`, to my knowledge, does not get parsed by jdt.ls, and `java.project.referencedLibraries` (confusingly) only includes compiled jars.


