### PR TITLE
Add jdt.ls.bundles option to load bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,12 @@
           "description": "Specifies the folder path to the JDK (17 or more recent) used to launch the Java Language Server. This setting will replace the Java extension's embedded JRE to start the Java Language Server. \n\nOn Windows, backslashes must be escaped, i.e.\n\"java.jdt.ls.java.home\":\"C:\\\\Program Files\\\\Java\\\\jdk-17.0_3\"",
           "scope": "machine-overridable"
         },
+        "java.jdt.ls.bundles": {
+          "type": "array",
+          "default": [],
+          "scope": "window",
+          "description": "Additional bundles to load when starting jdt.ls, e.g. those from vscode-java-debug, vscode-java-test, etc."
+        },
         "java.jdt.ls.vmargs": {
           "type": [
             "string",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,6 +3,7 @@
 import { commands, Extension, extensions, window } from 'coc.nvim'
 import * as path from 'path'
 import { Commands } from './commands'
+import { getJavaConfiguration } from './utils'
 
 export let existingExtensions: Array<string> = []
 export let buildFilePatterns: Array<string> = []
@@ -21,6 +22,10 @@ export function collectJavaExtensions(extensions: readonly Extension<any>[]): st
         }
       }
     }
+  }
+  const userBundles = getJavaConfiguration().get<string[]>("jdt.ls.bundles")
+  for (const bundle of userBundles) {
+    result.push(bundle)
   }
   // Make a copy of extensions:
   existingExtensions = result.slice()


### PR DESCRIPTION
To integrate nvim-jdtls/nvim-dap with coc.nvim, bundles from [1][2] need
to be loaded.

At the moment this is only possible via CoC extension's javaExtensions,
but it's quite an overkill to create new extensions for this since the
rest of the code is written in Lua.

So adding a new option to allow users to do this themselves.

[1] https://github.com/microsoft/java-debug
[2] https://github.com/microsoft/vscode-java-test

---

See also https://github.com/mfussenegger/nvim-jdtls/discussions/450
