### PR TITLE
Use configs from jdt.ls.directory if given

### DIFF
--- a/src/javaServerStarter.ts
+++ b/src/javaServerStarter.ts
@@ -169,6 +169,9 @@ function prepareParams(requirements: RequirementsData, javaConfiguration, worksp
   if (startedFromSources()) { // Dev Mode: keep the config.ini in the installation location
     console.log(`Starting jdt.ls ${isSyntaxServer ? '(syntax)' : '(standard)'} from vscode-java sources`)
     params.push(path.resolve(__dirname, '../server', configDir))
+  } else if (directory) {
+    console.log(`Starting jdt.ls ${isSyntaxServer ? '(syntax)' : '(standard)'} from custom directory ${directory}`)
+    params.push(path.resolve(directory, configDir))
   } else {
     params.push(resolveConfiguration(context, configDir))
   }


### PR DESCRIPTION
When jdt.ls.directory is set, we should use configs from this directory
as they may not be compatible with the ones shipped with coc-java
itself.
