### PR TITLE
Use supplied -javaagent param for lombok

### DIFF
--- a/src/lombokSupport.ts
+++ b/src/lombokSupport.ts
@@ -88,6 +88,9 @@ export function addLombokParam(context: ExtensionContext, params: string[]) {
       deleteIndex.push(i)
     }
   }
+  
+  const lastMatchedParam = params[deleteIndex[deleteIndex.length - 1]];
+
   for (let i = deleteIndex.length - 1; i >= 0; i--) {
     params.splice(deleteIndex[i], 1)
   }
@@ -95,6 +98,13 @@ export function addLombokParam(context: ExtensionContext, params: string[]) {
   // use the extension's Lombok version by default.
   isExtensionLombok = true
   let lombokJarPath: string = context.workspaceState.get(JAVA_LOMBOK_PATH)
+  
+  // use the supplied lombok jar-path if the above statement resolves to
+  // undefined
+  if (!lombokJarPath && !!lastMatchedParam) {
+    lombokJarPath = lastMatchedParam.replace('-javaagent:', '');
+  }
+
   if (lombokJarPath && fse.existsSync(lombokJarPath)) {
     if (isCompatibleLombokVersion(lombokPath2VersionNumber(lombokJarPath))) {
       isExtensionLombok = false


### PR DESCRIPTION
Fix #240 

### What was noticed
The [addLombokParam function](https://github.com/neoclide/coc-java/blob/1470028225bf7f5679cc736afe2051398d166c8f/src/lombokSupport.ts#L82) does the resolution of the lombokJarPath. It does this by first scanning through the supplied params and removing any of the param that starts with -javaagent and ends with .jar. These are the javaagent declarations that are being made using "java.jdt.ls.vmargs" - the ones supplied by the user. 

After this, the lomboxJarPath is resolved from the workspaceState [here](https://github.com/neoclide/coc-java/blob/1470028225bf7f5679cc736afe2051398d166c8f/src/lombokSupport.ts#L97) (looks hairy sort of). If that fails, it fallbacks to the extension's own lombok def, which in the real sense was not packaged with the extension, as it's meant to be located at {project}/lombok/lombok.jar.

So basically, the fallback does not exist and the one in the workspaceState does not exist either, meanwhile, the one supplied by the user using "java.jdt.ls.vmargs" has been thrown away. It wasn't even considered at all.

### What was done
If perhaps a user has supplied a -javaagent param in "java.jdt.ls.vmargs", look through the ones that has been marked for deletion and cache the last one before deleting them.

Then try resolving from workspaceState (don't really know what that does, as the statement itself looks somewhat hairy [@here](https://github.com/neoclide/coc-java/blob/1470028225bf7f5679cc736afe2051398d166c8f/src/lombokSupport.ts#L97)), if that fails, extract the jar path from the user-supplied path and try resolving that. If it fails too, fallback to the extension's own lombok.


